### PR TITLE
Work around false positive in triangulation check

### DIFF
--- a/Source/HoudiniEngine/Private/UnrealMeshTranslator.cpp
+++ b/Source/HoudiniEngine/Private/UnrealMeshTranslator.cpp
@@ -2841,7 +2841,8 @@ FUnrealMeshTranslator::CreateAndPopulateMeshPartFromMeshDescription(
 	const uint32 NumVertexInstances = NumTriangles * 3;
 
 	// Some checks: we expect triangulated meshes
-	if (MeshDescription.VertexInstances().Num() != NumTriangles * 3)
+	const UHoudiniRuntimeSettings* HoudiniRuntimeSettings = GetDefault<UHoudiniRuntimeSettings>();
+	if (HoudiniRuntimeSettings->bEnableStaticMeshTriangulationCheck && MeshDescription.VertexInstances().Num() != NumTriangles * 3)
 	{
 		HOUDINI_LOG_ERROR(TEXT("Expected a triangulated mesh, but # VertexInstances (%d) != # Triangles * 3 (%d)"), MeshDescription.VertexInstances().Num(), NumTriangles * 3);
 		return false;

--- a/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.cpp
@@ -110,6 +110,9 @@ UHoudiniRuntimeSettings::UHoudiniRuntimeSettings( const FObjectInitializer & Obj
 	// Spline marshalling
 	MarshallingSplineResolution = 50.0f;
 
+	// Static Mesh marshalling
+	bEnableStaticMeshTriangulationCheck = false;
+
 	// Static mesh proxy refinement settings
 	bEnableProxyStaticMesh = true;
 	bShowDefaultMesh = true;

--- a/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.h
@@ -323,6 +323,10 @@ protected:
 		UPROPERTY(GlobalConfig, EditAnywhere, Category = "GeometryMarshalling", meta = (DisplayName = "Curves - Default spline resolution (cm)"))
 		float MarshallingSplineResolution;
 
+		// Enable validation that exported static mesh data is correctly triangulated
+		UPROPERTY(GlobalConfig, EditAnywhere, Category = "GeometryMarshalling", meta = (DisplayName = "Static Mesh - Enable triangulation check"))
+		bool bEnableStaticMeshTriangulationCheck;
+
 		//-------------------------------------------------------------------------------------------------------------
 		// Static Mesh Options
 		//-------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR is to workaround an issue preventing meshes generated by the rockify tool from being processed by the scatter_objects tool.

The plugin is failing to export the mesh data for the rockify mesh. This is caused by it failing a validation check to ensure the geometry is correctly triangulated.

From what I can tell, this seems to be a false positive with the check. The internal Unreal representation of geometry data has an extra level of indirection when defining vertex attributes. This seems to be a mechanism for allowing the same vertex/position to be re-used with different sets of attributes.

The terminology:
**VertexId**: Index into the vertex position buffer
**VertexInstanceId**: Extra indirection layer. Used to index into attribute buffers. Mapped to VertexId with VertexInstanceVertices mapping.
**TriangleID**: Contains a list of 3 VertexInstanceIds.
**PolygonId**: Contains an array of TriangleID

This check appears to be trying to validate the number of vertexes matches the triangle count. However it doesn't seem to be taking into account that VertexInstanceIds can be re-used between multiple triangles.

In the Houdini representation, it doesn't seem to support this vertex re-use. In the exporter code below, it is de-duping these "VertexInstanceIds" and flattening it out to remove the extra layer of indirection. So skipping over this check I don't think will require any further changes to the exporter code from what I can tell.

From the error message, it sounds like this is trying to detect a mesh that is in a quad format and is not triangulated? Or if there are TrianglePolygons that are incorrectly constructed to have more than 3 vertexes? I am not sure the best way to modify this check without knowing what the original problem was. I wasn't able to find any more context from looking into the original repo's commit history.

So just going to disable the check for now.
